### PR TITLE
Use GitHub README as course homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,25 +381,15 @@ The first question of the exam will be an open question: "You get 5 minutes to t
 
 
 # Behind the scenes
-
-
+For instructors:
 
 > [!IMPORTANT]
-> View the **notebooks online**: https://bmlip.github.io/course/
+> The Pluto notebooks in this repository (`.jl` files) are automatically rendered on our website. You can view them online at https://bmlip.github.io/course/, and copy URLs from this index to use in the course schedule.
 >
 > *Status for live interactivity (PlutoSliderServer):* [![Better Stack Badge](https://uptime.betterstack.com/status-badges/v1/monitor/1svzl.svg)](https://tue-bmlip.betteruptime.com/)
 
 
-
-
-This is the *new* version of the course [Bayesian Machine Learning and Information Processing](https://github.com/bertdv/BMLIP). ✨
-
-There will be new lecture materials based on [Pluto.jl](https://plutojl.org/) with interactivity and color!
-
-
-
-
-# How to modify lecture materials
+## How to modify lecture materials
 
 Take a look at https://github.com/bmlip/course/tree/main/developer%20instructions for more information aimed at the course lecturers and website admins.
 


### PR DESCRIPTION
This moves the course homepage content (`bmlip.md` for biaslab-hugo) to the README.md of this repository. This gives a really easy setup! It works like this:

- Students can read the course homepage here, and they use the same website to browse materials and files. (Which can reduce confusion between two different places: biaslab.org and github.com.)
- We can edit the course homepage either:
  - Using VS Code + GitHub Desktop, just like editing Pluto notebooks with Pluto + GitHub Desktop
  - Directly with the GitHub web interface (see docs https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/quickstart-for-writing-on-github )

# Updated URLs
I also updated all URLs to point to the material in the new repository

# bmlip.nl
And we should set `bmlip.nl` as a redirect to

https://github.com/bmlip/course#readme

(which will show the course introduction and schedule after this PR is merged)
