### PR TITLE
Fix some LaTeX in exercises

### DIFF
--- a/exercises/Solutions-Dynamic-Models.jl
+++ b/exercises/Solutions-Dynamic-Models.jl
@@ -10,20 +10,42 @@ md"""
 
   * **[1]** (##) Given the Markov property
 
-\begin{equation*} p(x*n|x*{n-1},x*{n-2},\ldots,x*1) = p(x*n|x*{n-1}) \tag{A1} \end{equation*} proof that, for any ``n``, \begin{align*} p(x*n,x*{n-1},&\ldots,x*{k+1},x*{k-1},\ldots,x*1|x*k) = \
-&p(x*n,x*{n-1},\ldots,x*{k+1}|x*k) \cdot p(x*{k-1},x*{k-2},\ldots,x*1|x*k) \tag{A2}\,. \end{align*} In other words, proof that, if the Markov property A1 holds, then, given the "present" (``x_k``), the "future" ``(x_n,x_{n-1},\ldots,x_{k+1})`` is *independent* of the "past" ``(x_{k-1},x_{k-2},\ldots,x_1)``.
+```math
+p(x*n|x*{n-1},x*{n-2},\ldots,x*1) = p(x*n|x*{n-1}) \tag{A1}
+```
+
+proof that, for any ``n``,
+
+```math
+p(x*n,x*{n-1},\ldots,x*{k+1},x*{k-1},\ldots,x*1|x*k) = p(x*n,x*{n-1},\ldots,x*{k+1}|x*k) \cdot p(x*{k-1},x*{k-2},\ldots,x*1|x*k) \tag{A2}
+```
+
+In other words, proof that, if the Markov property A1 holds, then, given the "present" (``x_k``), the "future" ``(x_n,x_{n-1},\ldots,x_{k+1})`` is *independent* of the "past" ``(x_{k-1},x_{k-2},\ldots,x_1)``.
 
 > First, we rewrite A2 as
 
 
-\begin{align*} p(&x*n,x*{n-1},\ldots,x*{k+1},x*{k-1},\ldots,x*1|x*k) = \frac{p(x*n,x*{n-1},\ldots,x*1)}{p(x*k)} \
-&= \frac{p(x*n,x*{n-1},\ldots,x*{k+1}|x*k,\ldots,x*1) \cdot p(x*k,x*{k-1},\ldots,x*1)}{p(x*k)} \
-&= p(x*n,x*{n-1},\ldots,x*{k+1}|x*k,\ldots,x*1) \cdot p(x*{k-1},\ldots,x*1|x_k) \tag{A3} \end{align*} The first term in A3 can be simplified if A1 holds to  \begin{align*} p(x*n,&x*{n-1},\ldots,x*{k+1}|x*k,x*{k-1},\ldots,x*1) \
-&= p(x*n|x*{n-1},x*{n-2},\ldots,x*1) \cdot p(x*{n-1}|x*{n-2},x*{n-3},\ldots,x*1) \cdots \
-&\quad \cdots p(x*{k+1}|x*{k},x*{k-2},\ldots,x*1) \
-&= p(x*n|x*{n-1},x*{n-2},\ldots,x*k) \cdot p(x*{n-1}|x*{n-2},x*{n-3},\ldots,x*k) \cdots \
-&\quad \cdots p(x*{k+1}|x*{k}) \
-&= p(x*n,x*{n-1},\ldots,x*{k+1}|x*k) \tag{A4} \end{align*} Substitution of A4 into A3 leads to A2. QED.
+```math
+\begin{align}
+p(x*n,x*{n-1},\ldots,x*{k+1},x*{k-1},\ldots,x*1|x*k) &= \frac{p(x*n,x*{n-1},\ldots,x*1)}{p(x*k)} \\
+&= \frac{p(x*n,x*{n-1},\ldots,x*{k+1}|x*k,\ldots,x*1) \cdot p(x*k,x*{k-1},\ldots,x*1)}{p(x*k)} \\
+&= p(x*n,x*{n-1},\ldots,x*{k+1}|x*k,\ldots,x*1) \cdot p(x*{k-1},\ldots,x*1|x_k) \tag{A3}
+\end{align}
+```
+
+The first term in A3 can be simplified if A1 holds to
+
+```math
+\begin{align}
+p(x*n,x*{n-1},\ldots,x*{k+1}|x*k,x*{k-1},\ldots,x*1) &= p(x*n|x*{n-1},x*{n-2},\ldots,x*1) \cdot p(x*{n-1}|x*{n-2},x*{n-3},\ldots,x*1) \cdots \\
+&\quad \cdots p(x*{k+1}|x*{k},x*{k-2},\ldots,x*1) \\
+&= p(x*n|x*{n-1},x*{n-2},\ldots,x*k) \cdot p(x*{n-1}|x*{n-2},x*{n-3},\ldots,x*k) \cdots \\
+&\quad \cdots p(x*{k+1}|x*{k}) \\
+&= p(x*n,x*{n-1},\ldots,x*{k+1}|x*k) \tag{A4}
+\end{align}
+```
+
+Substitution of A4 into A3 leads to A2. QED.
 
   * **[2]** (#)      (a) What's the difference between a hidden Markov model and a linear Dynamical system?    
 

--- a/exercises/Solutions-Regression.jl
+++ b/exercises/Solutions-Regression.jl
@@ -75,7 +75,7 @@ with ``y, X`` and ``w`` as defined in the notebook.         (a) Work out the max
 \begin{equation*} w_{MAP} = (X^TX+\frac{\alpha}{\beta}I)^{-1}X^Ty  \end{equation*}
 ```
 
-> The MAP solution weighs both the prior and likelihood. If :\frac{\alpha}{\beta} $ is close to zero (if the prior is uninformative), then the ML solution and MAP solutions are close to each other.
+> The MAP solution weighs both the prior and likelihood. If ``\frac{\alpha}{\beta}`` is close to zero (if the prior is uninformative), then the ML solution and MAP solutions are close to each other.
 
 
   * **[3]** (###) Show that the variance of the predictive distribution for linear regression decreases as more data becomes available.
@@ -182,7 +182,7 @@ where ``f(x_n)`` is an ``M``-dimensional feature vector of input ``x_n``; ``y_n`
 
 (d) What is the predicted output value ``y_\bullet``, given an observation ``x_\bullet`` and the maximum likelihood parameters ``\hat \theta_{\text{ml}}``. Work this expression out in terms of ``F``, ``y`` and ``f(x_\bullet)``.      
 
-> Prediction of new data point: :\hat y*\bullet = \hat \theta^T f(x*\bullet) = \left((F^TF)^{-1}F^Ty\right)^T  f(x_\bullet) $
+> Prediction of new data point: ``\hat y_\bullet = \hat \theta^T f(x_\bullet) = \left((F^TF)^{-1}F^Ty\right)^T  f(x_\bullet)``
 
 
 (e) Suppose that, before the data set ``D`` was observed, we had reason to assume a prior distribution ``p(\theta)=\mathcal{N}(0,\sigma_0^2)``. Derive the Maximum a posteriori (MAP) estimate ``\hat \theta_{\text{map}}``.(hint: work this out in the ``\log`` domain.)                

--- a/exercises/Solutions-The-Gaussian-Distribution.jl
+++ b/exercises/Solutions-The-Gaussian-Distribution.jl
@@ -221,7 +221,9 @@ p_z(z) = \mathcal{N}(z \,|\, A(\mu_x-\mu_y)+b, \, A (\sigma_x^2 + \sigma_y^2) A^
 md"""
   * **[6]** (###) Compute
 
+```math
 \begin{equation*}         \int_{-\infty}^{\infty} \exp(-x^2)\mathrm{d}x \,.     \end{equation*}
+```
 
 > For a Gaussian with zero mean and varance equal to ``1`` we have
 


### PR DESCRIPTION
This fixes some of the missing latex characters in the Solutions jl files.

Be sure to read the `.jl` files in the `exercises/` folder, not the ipynb files.