### PR TITLE
Fix broken mini link in Regression

### DIFF
--- a/lectures/Regression.jl
+++ b/lectures/Regression.jl
@@ -141,7 +141,7 @@ md"""
 
 We observe ``N`` IID data **pairs** ``D=\{(x_1,y_1),\dotsc,(x_N,y_N)\}`` with ``x_n \in \mathbb{R}^M`` and ``y_n \in \mathbb{R}``.
 
-Assume that, based on the data set,  we are interested in predicting the response ``y_\bullet`` for a new **given and fixed** input observation ``x_\bullet = a``? 
+Assume that, based on the data set,  we are interested in predicting the response ``y_\bullet`` for a new **given and fixed** input observation ``x_\bullet = a``?
 
 In a Bayesian (generative) modeling context, we should develop a joint model for all variables, i.e., we should develop a model ``p(y_n,x_n)``, but in this case we already know ``p(x_n) = \delta(x_n-a)``.
 


### PR DESCRIPTION
The broken mini link in B7 Regression today was caused by the accidental file rename in https://github.com/bmlip/course/commit/9e5a290208195c6ea08caf21c928a193dc33348c and https://github.com/bmlip/course/commit/02896daa1e38c47281af0656df187bb75ddd68f9 , combined with a too-aggressive cache.

I fix it in this PR by invalidating the cache so the notebook will render again.

I also fixed it for future cases by changing how NotebookCard works, avoiding the cache: https://github.com/JuliaPluto/PlutoUI.jl/pull/329